### PR TITLE
Fix broken repo links

### DIFF
--- a/frontend/components/RepositoryPage.tsx
+++ b/frontend/components/RepositoryPage.tsx
@@ -86,7 +86,7 @@ function fixImageUrls(markdown: string, repoOwner: string, repoName: string, bra
     'https://raw.githubusercontent.com/$1/$2/$3/$4'
   );
 
-  result = fixRepoResourceUrls(markdown, repoOwner, repoName, safeBranch)
+  result = fixRepoResourceUrls(result, repoOwner, repoName, safeBranch)
   
   return result;
 }
@@ -94,10 +94,9 @@ function fixImageUrls(markdown: string, repoOwner: string, repoName: string, bra
 function fixRepoResourceUrls(markdown: string, repoOwner: string, repoName: string, branch?: string ) {
   const safeBranch = branch || "main";
   // Fix repository resources URLs
-  let result = markdown.replace(/\]\(([^http]\S+[^\)])\)/gi, (match, raw_resource) => {
+  let result = markdown.replace(/\]\(((?!http)\S+[^\)])\)/gi, (match, raw_resource) => {
     const resource = getFormattedRepoResource(raw_resource);
     const url = `https://github.com/${repoOwner}/${repoName}/tree/${safeBranch}/${resource}`;
-    console.log("match", match, "group", raw_resource, url);
     return `](${url})`;
   });
 

--- a/frontend/components/RepositoryPage.tsx
+++ b/frontend/components/RepositoryPage.tsx
@@ -85,6 +85,13 @@ function fixImageUrls(markdown: string, repoOwner: string, repoName: string, bra
     /https:\/\/github\.com\/([^/]+)\/([^/]+)\/blob\/([^/]+)\/([^\")\s]+)/g,
     'https://raw.githubusercontent.com/$1/$2/$3/$4'
   );
+  // Fix repository resources URLs
+  result = result.replace(/\]\(([^http]\S*)\)/gi, (match) => {
+    // console.log(match);
+    const cleanPath = match.substring(2, match.length-1);
+    return `](https://github.com/${repoOwner}/${repoName}/tree/${safeBranch}/${cleanPath})`;
+  });
+  console.log(markdown)
   return result;
 }
 

--- a/frontend/components/RepositoryPage.tsx
+++ b/frontend/components/RepositoryPage.tsx
@@ -95,26 +95,31 @@ function fixRepoResourceUrls(markdown: string, repoOwner: string, repoName: stri
   const safeBranch = branch || "main";
   // Fix repository resources URLs
   let result = markdown.replace(/\]\(([^http]\S+[^\)])\)/gi, (match, raw_resource) => {
-    const leading_chars = raw_resource.substring(0,2);
-    let potential_resource = raw_resource;
-    if (leading_chars === "./") {
-      potential_resource = raw_resource.substring(2);
-    } else if (leading_chars[0] === "/") {
-      potential_resource = raw_resource.substring(1);
-    }
-    const resource = potential_resource
+    const resource = getFormattedRepoResource(raw_resource);
     const url = `https://github.com/${repoOwner}/${repoName}/tree/${safeBranch}/${resource}`;
     console.log("match", match, "group", raw_resource, url);
     return `](${url})`;
   });
 
   // Fixing link definitions that point to repository resources URLs
-  result = result.replace(/(\[\S*\]\:)\s*([^\s&^http&^mailto]\S*)/gi, (_, variable, value) => {
+  result = result.replace(/(\[\S*\]\:)\s*([^\s&^http&^mailto]\S*)/gi, (_, variable, raw_resource) => {
+    const resource = getFormattedRepoResource(raw_resource);
     const url = `https://github.com/${repoOwner}/${repoName}/tree/${safeBranch}`
-    return `${variable} ${url}/${value}`;
+    return `${variable} ${url}/${resource}`;
   });
 
   return result;
+}
+
+function getFormattedRepoResource(raw_resource: string) {
+  const leading_chars = raw_resource.substring(0,2);
+  let potential_resource = raw_resource;
+  if (leading_chars === "./") {   
+    potential_resource = raw_resource.substring(2);
+  } else if (leading_chars[0] === "/") {
+    potential_resource = raw_resource.substring(1);
+  }
+  return potential_resource;
 }
 
 function ReadmeViewer({ source, repoOwner, repoName, branch }: ReadmeViewerProps) {

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,60 @@
+# Testing documentation
+
+This document describes how to execute the testcases for the different 
+components of the application
+
+## Frontend
+
+### Selenium test - Finding and checking github links
+At this stage, the script relies on localhost instead of Docker container names.
+
+**Requirements**
+- Python >= 3.9
+- Firefox Browser
+
+1. **Create Environment File**
+
+   - **DB conn & Frontend url:**
+     - Create a file at `tests/frontend/selenium/.env` with:
+       ```
+       POSTGRES_DB_URL=postgresql://postgres:orb@localhost:5432/sample
+       FRONTEND_URL=http://localhost:8000
+       ```
+       (Notice the use of localhost instead of the Docker container name)
+
+2. **Virtual environtment (venv) Setup**
+
+   Add a .venv directory at `tests/frontend/selenium` with:
+
+   ```bash
+   python -m venv .venv
+   ```
+
+   Activate virtual environment:
+   - On Linux/MacOS
+   ```bash
+   source venv/bin/activate
+   ```
+   - On Windows - Powershell
+   ```bash
+   .\.venv\Scripts\Activate.ps1
+   ```
+   - On Windows - Command Prompt
+   ```bash
+   .\.venv\Scripts\activate
+   ```
+   
+   Add all requirements:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. **Run script**
+
+   From `tests/frontend/selenium`, run:
+   ```bash
+   python test_repository_pages_links.py
+   ```
+   This will open a firefox web browser that will iterate through all repository pages
+   to retrieve for all the links on the attributes `href` of the `<a>` tags and
+   proceed to test them.

--- a/tests/frontend/selenium/requirements.txt
+++ b/tests/frontend/selenium/requirements.txt
@@ -1,0 +1,5 @@
+pytest
+requests
+psycopg[binary]
+python-dotenv
+selenium==4.34.2

--- a/tests/frontend/selenium/test_repository_pages_links.py
+++ b/tests/frontend/selenium/test_repository_pages_links.py
@@ -8,12 +8,30 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from dotenv import load_dotenv
 
-def db_conn(query_exec):
-    load_dotenv()
+def getCursor(query: str):
+    """
+    Description: To execute a query on the postgres DB by creating a connection
+        object
+    Parameters:
+        - `query` (string): The query to execute onto the DB
+    Returns: psycopg.Cursor. Object that has information regarding the 
+        execution of the query
+    Pre-conditions: A Postgres DB must be running at the given `POSTGRES_DB_URL`
+        env variable
+    Post-conditions: Queries can make changes into the DB
+    Exceptions:
+       - psycopg.errors: A family of exceptions regarding DB postgress operations
+    """
     with psycopg.connect(os.environ['POSTGRES_DB_URL']) as conn:
-        return query_exec(conn)
+        return conn.execute(query)
 
 def getWebDriver():
+    """
+    Description: To create a selenium web driver that can open a web browser for
+        frontend testing
+    Returns: WebDriver: The object that will conduct the interaction with the frontend
+        of a given url
+    """
     options = webdriver.FirefoxOptions()
     options.add_argument('--ignore-ssl-errors=yes')
     options.add_argument('--ignore-certificate-errors')
@@ -21,15 +39,20 @@ def getWebDriver():
         options=options
     )
 
-def find_broken_links(url):
-    load_dotenv()
+def find_broken_links(url: str):
     """
-    Finds and reports broken links on a given URL using Selenium and requests.
+    Description: Finds and reports broken links on a given URL using Selenium
+        and requests.
+    Parameters: 
+        - url: The url under test for broken links
+    Pre-conditions: `url` must be reachible by the host machine
+    Post-conditions: Print in the console the broken links found
     """
     driver = getWebDriver()
     driver.get(url)
     print (f"For URL {url}")
 
+    # Wait 10 secs or until a <h1> tag has been rendered
     WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.TAG_NAME, "h1")))
 
     links = driver.find_elements(By.TAG_NAME, 'a')
@@ -45,8 +68,18 @@ def find_broken_links(url):
         print(f"- {link} (Status: {status})")
     print()
 
-def get_broken_links(links):
+def get_broken_links(links: list[str]):
+    """
+    Description: Collect all the broken links found from a given list of those
+    Parameters:
+       - links: All the href urls found on a given frontend url
+    Returns: list[str]. The list of urls that are either malformed or return a
+        http error code
+    """
     base_url = os.environ["FRONTEND_URL"]
+
+    # The list of expected urls currently in the frontend app 
+    # (Not including the specific repo sites)
     valid_frontend_urls = list(map(
         lambda path: f"{base_url}/{path}",
         ["repositories", "about", "connect", ""]
@@ -54,6 +87,9 @@ def get_broken_links(links):
     broken_links = []
     for link in links:
         href = link.get_attribute('href')
+        # Skip if the href is an email request, or 
+        # if it's an external url not related to our site or our reconstructed 
+        # github.com links
         if not href or "mailto:" == href[:7] or (base_url not in href and "github.com" not in href):
             continue
         if base_url in href and href not in valid_frontend_urls:
@@ -68,15 +104,26 @@ def get_broken_links(links):
     return broken_links
 
 def test_all_repo_links():
-    load_dotenv()
+    """
+    Description: Iterate through all the repositories pages to check for broken
+       github.com links or for malformed links using the app frontend url
+    Pre-conditions:
+       - A Postgres DB must be running at the given `POSTGRES_DB_URL`
+        env variable
+       - Frontend app must be available and reacheable by the host maching at
+           at the given `FRONTEND_URL` env variable
+    Post-conditions: Print out of either a list of broken/malformed links, or 
+        a message indicating the none were found per each repo page.
+    """
     query = """
         SELECT id
         FROM  combined_repositories_showcase
     """
-    result = db_conn(lambda conn: conn.execute(query).fetchall())
+    result_cursor = getCursor(query)
+    result = result_cursor.fetchall()
     for tuple in result:
         find_broken_links(f"{os.environ['FRONTEND_URL']}/repositories/{tuple[0]}")
 
-# Example usage:
-# find_broken_links("http://localhost:3000/repositories/13")
+
+load_dotenv()
 test_all_repo_links()

--- a/tests/frontend/selenium/test_repository_pages_links.py
+++ b/tests/frontend/selenium/test_repository_pages_links.py
@@ -1,0 +1,67 @@
+import psycopg
+import requests
+import os
+
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from dotenv import load_dotenv
+
+def db_conn(query_exec):
+    load_dotenv()
+    with psycopg.connect(os.environ['POSTGRES_DB_URL']) as conn:
+        return query_exec(conn)
+
+def find_broken_links(url):
+    """
+    Finds and reports broken links on a given URL using Selenium and requests.
+    """
+
+    options = webdriver.FirefoxOptions()
+    options.add_argument('--ignore-ssl-errors=yes')
+    options.add_argument('--ignore-certificate-errors')
+    driver = webdriver.Firefox(
+        options=options
+    )
+    driver.get(url)
+    WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.TAG_NAME, "h1")))
+
+    links = driver.find_elements(By.TAG_NAME, 'a')
+    broken_links = []
+    print (f"For URL {url}")
+    for link in links:
+        href = link.get_attribute('href')
+        if "mailto:" == href[:7] or ("localhost" not in href and "github" not in href):
+            continue
+        print(href)
+        if href:  # Ensure href attribute exists
+            try:
+                response = requests.get(href, timeout=5)
+                if response.status_code >= 400:
+                    broken_links.append((href, response.status_code))
+            except requests.exceptions.RequestException as e:
+                broken_links.append((href, f"Error: {e}"))
+
+    driver.quit()
+
+    
+    if broken_links:
+        print(f"Broken links found on {url}:")
+        for link, status in broken_links:
+            print(f"- {link} (Status: {status})")
+    else:
+        print(f"No broken links found on {url}.")
+
+def test_all_repo_links():
+    query = """
+        SELECT id
+        FROM  combined_repositories_showcase
+    """
+    result = db_conn(lambda conn: conn.execute(query).fetchall())
+    for tuple in result:
+        find_broken_links(f"http://localhost:3000/repositories/{tuple[0]}")
+
+# Example usage:
+# find_broken_links("http://localhost:3000/repositories/13")
+test_all_repo_links()

--- a/tests/frontend/selenium/test_repository_pages_links.py
+++ b/tests/frontend/selenium/test_repository_pages_links.py
@@ -13,54 +13,69 @@ def db_conn(query_exec):
     with psycopg.connect(os.environ['POSTGRES_DB_URL']) as conn:
         return query_exec(conn)
 
-def find_broken_links(url):
-    """
-    Finds and reports broken links on a given URL using Selenium and requests.
-    """
-
+def getWebDriver():
     options = webdriver.FirefoxOptions()
     options.add_argument('--ignore-ssl-errors=yes')
     options.add_argument('--ignore-certificate-errors')
-    driver = webdriver.Firefox(
+    return webdriver.Firefox(
         options=options
     )
+
+def find_broken_links(url):
+    load_dotenv()
+    """
+    Finds and reports broken links on a given URL using Selenium and requests.
+    """
+    driver = getWebDriver()
     driver.get(url)
+    print (f"For URL {url}")
+
     WebDriverWait(driver, 10).until(EC.presence_of_element_located((By.TAG_NAME, "h1")))
 
     links = driver.find_elements(By.TAG_NAME, 'a')
+    broken_links = get_broken_links(links)
+    
+    driver.quit()
+    
+    if broken_links == []:
+        print(f"No malformed frontend or broken github links found\n")
+        return
+    print(f"Broken links found on {url}:")
+    for link, status in broken_links:
+        print(f"- {link} (Status: {status})")
+    print()
+
+def get_broken_links(links):
+    base_url = os.environ["FRONTEND_URL"]
+    valid_frontend_urls = list(map(
+        lambda path: f"{base_url}/{path}",
+        ["repositories", "about", "connect", ""]
+    ))
     broken_links = []
-    print (f"For URL {url}")
     for link in links:
         href = link.get_attribute('href')
-        if "mailto:" == href[:7] or ("localhost" not in href and "github" not in href):
+        if not href or "mailto:" == href[:7] or (base_url not in href and "github.com" not in href):
             continue
-        print(href)
-        if href:  # Ensure href attribute exists
-            try:
-                response = requests.get(href, timeout=5)
-                if response.status_code >= 400:
-                    broken_links.append((href, response.status_code))
-            except requests.exceptions.RequestException as e:
-                broken_links.append((href, f"Error: {e}"))
-
-    driver.quit()
-
-    
-    if broken_links:
-        print(f"Broken links found on {url}:")
-        for link, status in broken_links:
-            print(f"- {link} (Status: {status})")
-    else:
-        print(f"No broken links found on {url}.")
+        if base_url in href and href not in valid_frontend_urls:
+            broken_links.append((href, f"Error: It is a malformed URL"))
+            continue
+        try:
+            response = requests.get(href, timeout=5)
+            if response.status_code >= 400:
+                broken_links.append((href, response.status_code))
+        except requests.exceptions.RequestException as e:
+            broken_links.append((href, f"Error: {e}"))
+    return broken_links
 
 def test_all_repo_links():
+    load_dotenv()
     query = """
         SELECT id
         FROM  combined_repositories_showcase
     """
     result = db_conn(lambda conn: conn.execute(query).fetchall())
     for tuple in result:
-        find_broken_links(f"http://localhost:3000/repositories/{tuple[0]}")
+        find_broken_links(f"{os.environ['FRONTEND_URL']}/repositories/{tuple[0]}")
 
 # Example usage:
 # find_broken_links("http://localhost:3000/repositories/13")


### PR DESCRIPTION
Here are the changes I did to fix the issue of broken links for repository resources. The only project change was on `RepositoryPage.tsx` on the frontend app directory. 

The remaining files were to create a tests directory to allocate all our testing code and a script that looks on all repository pages for broken github.com links or malformed urls using the app domain.

Let me know any addition/subtraction/modifications that will be needed.